### PR TITLE
(refs #21) : Update Alpine Linux's package version

### DIFF
--- a/redmine/redmine/Dockerfile
+++ b/redmine/redmine/Dockerfile
@@ -1,11 +1,10 @@
-#based on https://github.com/YoshinoriN/docker-rails/tree/master/ruby-2.3.1
 FROM ruby:2.3.1-alpine
 
 MAINTAINER YoshinoriN
 
 RUN apk update --no-cache \
   && apk add --no-cache --virtual build-dependencies libffi-dev build-base \
-  && apk add --no-cache mysql-client tzdata mariadb-dev=10.1.19-r0 linux-headers=4.4.6-r1 imagemagick-dev=6.9.5.9-r1 \
+  && apk add --no-cache mysql-client tzdata mariadb-dev=10.1.21-r0 linux-headers=4.4.6-r1 imagemagick-dev=6.9.5.9-r1 \
   && apk add --no-cache git \
   && mkdir -p /usr/src/app/redmine \
   && mkdir -p /usr/src/app/redmine/tmp/pids


### PR DESCRIPTION
mariadb-dev 10.1.19-r0 to 10.1.21-r0